### PR TITLE
Add client to be manually set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,13 @@
         "phpstan/phpstan": "^1.7",
         "phpunit/phpunit": "^9.5",
         "prestashop/php-dev-tools": "^4.2"
+    },
+    "scripts": {
+        "phpstan-g5": "vendor/bin/phpstan analyze -c tests/Guzzle5/phpstan.neon",
+        "phpstan-g7": "vendor/bin/phpstan analyze -c tests/Guzzle7/phpstan.neon",
+        "phpstan": [
+            "@phpstan-g5",
+            "@phpstan-g7"
+        ]
     }
 }

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -15,6 +15,11 @@ class ClientFactory
      */
     private $versionDetection;
 
+    /**
+     * @var ?ClientInterface
+     */
+    private $client;
+
     public function __construct(VersionDetection $versionDetection = null)
     {
         $this->versionDetection = $versionDetection ?: new VersionDetection();
@@ -25,10 +30,27 @@ class ClientFactory
      */
     public function getClient(array $config = []): ClientInterface
     {
+        if (!$this->client) {
+            $this->client = $this->initClient($config);
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function initClient(array $config = []): ClientInterface
+    {
         if ($this->versionDetection->getGuzzleMajorVersionNumber() >= 7) {
             return Guzzle7Client::createWithConfig($config);
         }
 
         return Guzzle5Client::createWithConfig($config);
+    }
+
+    public function setClient(ClientInterface $client): void
+    {
+        $this->client = $client;
     }
 }

--- a/src/VersionDetection.php
+++ b/src/VersionDetection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\ModuleLibGuzzleAdapter;
+namespace Prestashop\ModuleLibGuzzleAdapter;
 
 class VersionDetection
 {


### PR DESCRIPTION
Useful for testing, where we can set the [Mock Client](https://docs.php-http.org/en/latest/clients/mock-client.html) instead