### PR TITLE
Update library to be compatible with PrestaShop V9

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,7 @@ name: PHP tests
 on: [push, pull_request]
 jobs:
   php-linter:
-    name: PHP Syntax check 7.2|7.3|8.0|8.1
+    name: PHP Syntax check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,6 +16,15 @@ jobs:
 
       - name: PHP syntax checker 8.1
         uses: prestashop/github-action-php-lint/8.1@master
+
+      - name: PHP syntax checker 8.2
+        uses: prestashop/github-action-php-lint/8.2@master
+
+      - name: PHP syntax checker 8.3
+        uses: prestashop/github-action-php-lint/8.3@master
+
+      - name: PHP syntax checker 8.4
+        uses: prestashop/github-action-php-lint/8.4@master
 
   php-cs-fixer:
     name: PHP-CS-Fixer
@@ -78,7 +87,7 @@ jobs:
     name: PHPUnit
     strategy:
       matrix:
-        version: [7.2, 7.4, 8.1]
+        version: [7.2, 7.4, 8.1, 8.2, 8.3, 8.4]
     runs-on: ubuntu-latest
     steps:
       - name: Setup PHP with tools

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^2.0",
         "php-http/message": "^1.13",
         "php-http/httplug": "^2.3",
         "guzzlehttp/psr7": "^2.3.0"

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -17,7 +17,7 @@ class ClientFactory
      */
     private $versionDetection;
 
-    public function __construct(VersionDetection $versionDetection = null)
+    public function __construct(?VersionDetection $versionDetection = null)
     {
         $this->versionDetection = $versionDetection ?: new VersionDetection();
     }

--- a/src/Guzzle5/Client.php
+++ b/src/Guzzle5/Client.php
@@ -30,7 +30,7 @@ class Client implements ClientClientInterface
     /**
      * @param ClientInterface|null $client
      */
-    public function __construct(ClientInterface $client = null)
+    public function __construct(?ClientInterface $client = null)
     {
         $this->client = $client ?: new GuzzleClient();
     }
@@ -113,7 +113,7 @@ class Client implements ClientClientInterface
      * @param GuzzleExceptions\TransferException $exception
      * @param RequestInterface $request
      *
-     * @return Exception
+     * @return \Exception
      */
     private function handleException(GuzzleExceptions\TransferException $exception, RequestInterface $request)
     {

--- a/src/Guzzle7/Promise.php
+++ b/src/Guzzle7/Promise.php
@@ -73,7 +73,7 @@ final class Promise implements HttpPromise
     /**
      * {@inheritdoc}
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         return new static($this->promise->then($onFulfilled, $onRejected), $this->request);
     }


### PR DESCRIPTION
In PrestaShop V9 Guzzle has been removed from the core dependencies so it is not in the composer.lock at all anymore.
Also the league server library has been updated which indirectly required an update of the `psr/http-message` in which the interfaces are now stricter this can cause some PHP errors because methods' signatures don't match.

This PR aims at updating the library so that it can work with PrestaShop V9, it may mean that it won't be able to handle GUzzle5 and maybe even Guzzle7 that would need to be updated.

This is probably a breaking change and it will mean this library needs to be released with a new major version.

- Update `psr/http-message` version

### Important

This modification is made to ease the transition for modules towards PrestaShop V9, it maybe not work in the end and is probably the better solution. Instead of relying on Guzzle and som libraries that depend on it and adapt it the module should instead prioritize using the Symfony HTTP Client which is available in PrestaShop since the version `1.7.0` https://symfony.com/doc/6.4/http_client.html